### PR TITLE
Move Tailwind script to head section

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,9 @@
   <meta name="robots" content="index, follow">
   <title>Stagelink - Marketing Digital & Produção de Eventos</title>
   <meta name="description" content="Transformamos ideias em resultados digitais. Marketing Digital e Eventos Corporativos que impulsionam o seu negócio ao próximo nível.">
-  <link rel="icon" type="image/svg+xml" href="favicon.svg">  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="src/index.css">
   
 
@@ -363,7 +365,6 @@
   </div>
 
 
-  <script src="https://cdn.tailwindcss.com"></script>
   <script type="text/javascript"
         src="https://cdn.jsdelivr.net/npm/@emailjs/browser@4/dist/email.min.js">
   </script>


### PR DESCRIPTION
## Summary
- relocate Tailwind CDN script from the bottom of the page to the `<head>`
- place it right after the Google Fonts link and before the main stylesheet
- remove the old reference at the end of the document

## Testing
- `grep -n "cdn.tailwindcss.com" -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_6882c84c15ac83309d3d7b3ecb54bac4